### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![smithery badge](https://smithery.ai/badge/@imprvhub/mcp-status-observer)](https://smithery.ai/server/@imprvhub/mcp-status-observer)
 
-An integration that allows Claude Desktop to monitor and query the operational status of major digital platforms using the Model Context Protocol (MCP).
-
-<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer/badge" alt="Status Observer MCP server" />
-</a>
+<table style="border-collapse: collapse; width: 100%; table-layout: fixed;">
+<tr>
+<td style="width: 40%; padding: 15px; vertical-align: middle; border: none;">An integration that allows Claude Desktop to monitor and query the operational status of major digital platforms using the Model Context Protocol (MCP).</td>
+<td style="width: 60%; padding: 0; vertical-align: middle; border: none; min-width: 300px; text-align: center;"><a href="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer">
+  <img style="max-width: 100%; height: auto; min-width: 300px;" src="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer/badge" alt="Status Observer MCP server" />
+</a></td>
+</tr>
+</table>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An integration that allows Claude Desktop to monitor and query the operational status of major digital platforms using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer/badge" alt="Status Observer MCP server" />
+</a>
+
 ## Features
 
 - Monitor world's most used digital platforms (GitHub, Slack, Discord, etc.)
@@ -19,7 +23,6 @@ An integration that allows Claude Desktop to monitor and query the operational s
     <img src="public/assets/preview.png" width="600" alt="Status Observer MCP Demo">
   </a>
 </p>
-
 
 <details>
 <summary> Timestamps </summary>


### PR DESCRIPTION
This PR adds a badge for the [Status Observer MCP](https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-status-observer/badge" alt="Status Observer MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.